### PR TITLE
[Fix] Case sensitivity issues in Image import statement

### DIFF
--- a/src/components/Works/Works.jsx
+++ b/src/components/Works/Works.jsx
@@ -3,8 +3,8 @@ import './Works.css';
 import Upwork from "../../img/Upwork.png";
 import Fiverr from "../../img/fiverr.png";
 import Amazon from "../../img/amazon.png";
-import Shopify from "../../img/shopify.png";
-import Facebook from "../../img/facebook.png";
+import Shopify from "../../img/Shopify.png";
+import Facebook from "../../img/Facebook.png";
 import { themeContext } from '../../Context';
 import { useContext } from "react";
 


### PR DESCRIPTION
## Description

This pull request addresses and resolves the case sensitivity issues in the image import statements within the `Works.jsx` component. The incorrect casing was causing module not found errors during compilation or vercel deployment.

## Changes Made

- Corrected the import statements for the following images to match their exact file names on disk:
    - `Upwork.png`
    - `Fiverr.png`
    - `Amazon.png`
    - `Shopify.png`
    - `Facebook.png`

## Screenshot Error solved

**Before** 👇

![image](https://github.com/user-attachments/assets/91a3c284-5545-495a-bba5-818811fe7675)

<br>

**After** 👇

![{F8CDFD02-9E97-423B-BCBF-27C0915BFA0D}](https://github.com/user-attachments/assets/4d9631c9-99c3-4d0b-a2bf-7e39e39a3f84)

